### PR TITLE
feat: Implement WhatsApp conversation states and add API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ HealthGPT é um sistema modular com backend em Python que centraliza o atendimen
 
 - **Agendamento Inteligente**
 
-  - Validação automática de horários disponíveis
+  - Oferece opção de autoagendamento via link (Google Appointment Schedules).
+  - Permite agendamento conversacional interativo via WhatsApp.
+  - Validação automática de horários disponíveis (para fluxo conversacional).
   - Suporte a agendamentos particulares e por convênio
   - Verificação de convênios aceitos
-  - Solicitação e validação de documentos necessários
 
 - **Documentação Necessária**
 
   - Documento de identificação (obrigatório para todos)
   - Carteirinha do convênio (obrigatório para agendamentos por convênio)
+  - _Nota:_ No fluxo conversacional, o bot solicitará o envio dos documentos pelo chat. A verificação e armazenamento dos arquivos são realizados manualmente pela equipe.
 
 - **Convênios Aceitos**
 

--- a/app/api/whatsapp.py
+++ b/app/api/whatsapp.py
@@ -1,44 +1,337 @@
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+import os
+import json
+from fastapi import APIRouter, Request, Response, HTTPException, status, BackgroundTasks
+from dotenv import load_dotenv
 
 from app.services.whatsapp_service import WhatsAppService
+from app.services.conversation_state_service import ConversationStateService
+from app.services.scheduling_service import SchedulingService
+from app.services.appointment_orchestrator import AppointmentOrchestrator
+
+load_dotenv()
 
 router = APIRouter()
-service = WhatsAppService()
 
-# Modelos Pydantic para validar entrada/saída de dados
-class IncomingMessage(BaseModel):
-    from_: str  # número do remetente
-    text: str
+# Load the Verify Token from environment variables
+VERIFY_TOKEN = os.getenv("VERIFY_TOKEN")
+GOOGLE_SCHEDULES_LINK = os.getenv("GOOGLE_SCHEDULES_LINK", "[Insira seu link do Google Schedules aqui]") # Get link from .env or provide default
 
-    class Config:
-        fields = {'from_': 'from'}  # mapeia o campo JSON "from" para atributo from_
+# --- Webhook Verification (GET) ---
 
-class OutgoingMessage(BaseModel):
-    success: bool
-    detail: str
-    to: str
+@router.get("/webhook")
+async def verify_webhook(request: Request):
+    """ Handles Meta's webhook verification request. """
+    print("Received GET /webhook verification request")
+    
+    # Parse params from the webhook verification request
+    mode = request.query_params.get("hub.mode")
+    token = request.query_params.get("hub.verify_token")
+    challenge = request.query_params.get("hub.challenge")
 
-@router.post("/webhook", response_model=OutgoingMessage)
-async def whatsapp_webhook(msg: IncomingMessage):
+    # Check if a token and mode were sent
+    if mode and token:
+        # Check the mode and token sent are correct
+        if mode == "subscribe" and token == VERIFY_TOKEN:
+            # Respond with 200 OK and challenge token from the request
+            print(f"WEBHOOK_VERIFIED: Responding with challenge: {challenge}")
+            return Response(content=challenge, status_code=status.HTTP_200_OK)
+        else:
+            # Responds with '403 Forbidden' if verify tokens do not match
+            print(f"WEBHOOK_VERIFICATION_FAILED: Mode={mode}, Token={token} (Expected: {VERIFY_TOKEN})")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Verify token mismatch",
+            )
+    else:
+        # Responds with '400 Bad Request' if mode or token is missing
+        print("WEBHOOK_VERIFICATION_FAILED: Mode or token missing")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing hub.mode or hub.verify_token",
+        )
+
+# --- Handle Incoming Messages (POST) ---
+
+async def process_whatsapp_message(payload: dict):
     """
-    Endpoint que seria chamado pelo provedor de WhatsApp (webhook).
-    Recebe JSON:
-      { "from": "+5511999999999", "text": "Olá" }
-    Retorna:
-      { "success": true, "detail": "...", "to": "+5511999999999" }
+    Processes the incoming WhatsApp message payload in the background.
+    This is where the conversation state machine and logic will reside.
     """
+    print(f"Processing payload: {json.dumps(payload, indent=2)}")
+    
+    # Initialize services
+    state_service = ConversationStateService()
+    whatsapp_service = WhatsAppService()
+    # Instantiate other services as needed within the state handlers
+    # We might need ChatGPTService, SchedulingService, AppointmentOrchestrator
+    chatgpt_service = None # Lazy load if needed
+    scheduling_service = None # Lazy load if needed
+    orchestrator_service = None # Lazy load if needed
+
+    # --- 1. Extract relevant information from payload --- 
+    # Meta's payload structure is complex. Need to extract message type, text, phone number etc.
+    # Example (simplified, adjust based on actual Meta payload structure):
     try:
-        # Processa a mensagem recebida
-        incoming = {"from": msg.from_, "text": msg.text}
-        data = await service.receive_message(incoming)
+        # Change detection (only process messages)
+        if payload.get('object') == 'whatsapp_business_account':
+            entry = payload.get('entry', [{}])[0]
+            changes = entry.get('changes', [{}])[0]
+            value = changes.get('value', {})
+            message_data = value.get('messages', [{}])[0]
+            
+            if message_data:
+                phone_number = message_data.get('from')
+                message_type = message_data.get('type')
+                
+                if message_type == 'text':
+                    message_text = message_data.get('text', {}).get('body')
+                elif message_type == 'interactive': # e.g., button clicks
+                    # Extract data from interactive messages if you use them
+                    message_text = "Interactive Message Received" # Placeholder
+                else:
+                    # Handle other message types if needed (image, audio, location, etc.)
+                    print(f"Ignoring non-text/interactive message type: {message_type}")
+                    return
+                
+                if not phone_number or not message_text:
+                    print("Could not extract phone number or message text from payload.")
+                    return
+                    
+            else:
+                print("No message data found in payload.")
+                return
+        else:
+            # Not a whatsapp message notification
+            print("Ignoring non-whatsapp notification.")
+            return
+            
+    except (IndexError, KeyError, TypeError) as e:
+        print(f"Error parsing incoming payload: {e}. Payload: {payload}")
+        return
 
-        # Envia a resposta gerada pelo ChatGPT
-        sent = service.send_message(data['phone'], data['response'])
+    # --- 2. Get current conversation state --- 
+    current_state_info = state_service.get_state(phone_number)
+    state = "NEW" if current_state_info is None else current_state_info.get("state")
+    context = {} if current_state_info is None else current_state_info.get("context", {})
+    
+    # --- 3. Check if bot should ignore --- 
+    if state in ["COMPLETED", "HUMAN_TAKEOVER"]:
+        print(f"Ignoring message from {phone_number}. State: {state}")
+        return
+        
+    # --- 4. Implement State Machine Logic --- 
+    # TODO: Build the state machine logic here based on 'state' and 'message_text'
+    # This will involve calling ChatGPTService, SchedulingService etc. 
+    # and using state_service.save_state(phone_number, new_state, new_context)
+    
+    new_state = state # Placeholder
+    new_context = context # Placeholder
+    reply_message = "" # Placeholder
+    
+    if state == "NEW":
+        print(f"Handling NEW contact: {phone_number}")
+        # Initial response offering link or chat
+        reply_message = (
+            f"Olá! Bem-vindo(a) à clínica HealthGPT.\n\n"
+            f"Você pode ver meus horários e agendar diretamente aqui: {GOOGLE_SCHEDULES_LINK}\n\n"
+            f"Ou, se preferir, podemos fazer o agendamento aqui pelo chat. Como gostaria de prosseguir?"
+        )
+        new_state = "AWAITING_INITIAL_CHOICE" # Transition to next state
+        state_service.save_state(phone_number, new_state, new_context) 
+        
+    elif state == "AWAITING_INITIAL_CHOICE":
+        print(f"Handling AWAITING_INITIAL_CHOICE for {phone_number}. Message: '{message_text}'")
+        # TODO: Analyze if user wants link (ignore) or chat (start flow)
+        # Simplified: Assume any reply means they want to chat for now
+        if "link" in message_text.lower():
+             reply_message = f"Ok! Use este link para agendar: {GOOGLE_SCHEDULES_LINK}"
+             # Decide if you want to end the bot interaction here
+             state_service.save_state(phone_number, "REDIRECTED_TO_LINK", {"link_sent": True})
+        else:
+            reply_message = "Ok, vamos agendar por aqui. Você prefere atendimento particular ou por convênio?"
+            new_state = "AWAITING_TYPE"
+            state_service.save_state(phone_number, new_state, new_context)
+    
+    elif state == "AWAITING_TYPE":
+        print(f"Handling AWAITING_TYPE for {phone_number}. Message: '{message_text}'")
+        msg_lower = message_text.lower()
+        
+        # Simple keyword matching for now
+        if "particular" in msg_lower or "privado" in msg_lower:
+            new_context['is_private'] = True
+            # Send predefined info message for private consultations
+            # TODO: Define this message properly, maybe load from config or template
+            reply_message = (
+                "Entendido. O atendimento particular funciona assim: [Explicação sobre consulta particular, valores, etc.]. \n"
+                "Um de nossos atendentes entrará em contato para finalizar os detalhes e confirmar seu agendamento."
+            )
+            new_state = "HUMAN_TAKEOVER" # End bot flow here for private
+            state_service.save_state(phone_number, new_state, new_context)
+        elif "convênio" in msg_lower or "convenio" in msg_lower or "plano" in msg_lower:
+            new_context['is_private'] = False
+            reply_message = "Ok, qual o nome do seu convênio/plano de saúde?"
+            new_state = "AWAITING_INSURANCE_NAME"
+            state_service.save_state(phone_number, new_state, new_context)
+        else:
+            # Could use ChatGPT here for better understanding, but for now, ask again
+            reply_message = "Desculpe, não entendi. O atendimento seria particular ou por convênio?"
+            # Keep state as AWAITING_TYPE
+            state_service.save_state(phone_number, state, context) # Save context in case something useful was stored
+            
+    elif state == "AWAITING_INSURANCE_NAME":
+        print(f"Handling AWAITING_INSURANCE_NAME for {phone_number}. Message: '{message_text}'")
+        potential_insurance_name = message_text # Assume the message is the name for now
+        
+        if orchestrator_service is None: orchestrator_service = AppointmentOrchestrator()
+        
+        if orchestrator_service.validate_insurance(potential_insurance_name):
+            new_context['insurance_name'] = potential_insurance_name
+            # Ask for documents next
+            reply_message = (
+                f"Perfeito, atendemos {potential_insurance_name}. \n"
+                f"Para agilizar, por favor, envie aqui no chat fotos legíveis do seu documento de identidade (frente e verso) e da sua carteirinha do convênio (frente e verso)."
+            )
+            new_state = "AWAITING_DOCS_INSURANCE"
+            state_service.save_state(phone_number, new_state, new_context)
+        else:
+            accepted_list = ", ".join(orchestrator_service.ACCEPTED_INSURANCES)
+            reply_message = (
+                f"Desculpe, no momento não estamos atendendo o convênio '{potential_insurance_name}'. \n"
+                f"Aceitamos: {accepted_list}. \n"
+                f"Gostaria de seguir como particular ou tentar informar outro convênio?"
+            )
+            # Go back or ask to clarify?
+            # Let's go back to AWAITING_TYPE state for simplicity
+            new_state = "AWAITING_TYPE"
+            state_service.save_state(phone_number, new_state, context) # Reset context slightly?
+            
+    elif state == "AWAITING_DOCS_INSURANCE":
+        # User sent something after being asked for docs. Assume they sent them (as per requirement).
+        # Move to asking about slots.
+        print(f"Handling AWAITING_DOCS_INSURANCE for {phone_number}. Assuming docs received, asking for slots.")
+        # TODO: Implement slot fetching and presentation
+        reply_message = "Obrigado! Agora, sobre o agendamento, você tem alguma preferência de dia ou horário para a consulta?"
+        new_state = "AWAITING_SLOT_PREFERENCE"
+        state_service.save_state(phone_number, new_state, new_context)
+        
+    elif state == "AWAITING_SLOT_PREFERENCE":
+        print(f"Handling AWAITING_SLOT_PREFERENCE for {phone_number}. Message: '{message_text}'")
+        # For now, assume any response means they want to see available slots.
+        # TODO: Implement more sophisticated understanding of preference (e.g., date/time parsing).
+        
+        if scheduling_service is None: scheduling_service = SchedulingService()
+        
+        try:
+            available_slots = scheduling_service.get_available_slots()
+            
+            if not available_slots:
+                reply_message = "Desculpe, no momento não há horários disponíveis. Por favor, tente novamente mais tarde ou entre em contato conosco diretamente."
+                # Keep state or move to human? Let's keep for now, user might ask again.
+                new_state = state # Stay in AWAITING_SLOT_PREFERENCE
+                state_service.save_state(phone_number, new_state, context)
+            else:
+                # Format the slots for display
+                # TODO: Improve formatting, maybe add button options if platform supports
+                slot_options = []
+                for slot in available_slots:
+                    # Assuming slot object has 'start_time', 'end_time', 'slot_id'
+                    # Let's format start_time for simplicity
+                    try:
+                        # Attempt to parse and format. Adjust format as needed.
+                        from datetime import datetime
+                        start_dt = datetime.fromisoformat(slot['start_time'])
+                        formatted_time = start_dt.strftime("%d/%m/%Y às %H:%M") # Example: 25/07/2024 às 14:30
+                        slot_options.append(f"- {formatted_time} (ID: {slot['slot_id']})") # Include ID for selection
+                    except (ValueError, KeyError):
+                        slot_options.append(f"- Horário inválido (ID: {slot.get('slot_id', 'N/A')})")
+                        
+                reply_message = "Aqui estão os próximos horários disponíveis:\n" + "\n".join(slot_options) + "\n\nPor favor, digite o ID do horário que deseja escolher."
+                new_state = "AWAITING_SLOT_CHOICE"
+                state_service.save_state(phone_number, new_state, new_context)
+                
+        except Exception as e:
+            print(f"Error fetching or formatting slots: {e}")
+            reply_message = "Ocorreu um erro ao buscar os horários. Por favor, tente novamente mais tarde."
+            # Decide state: back to preference or human takeover?
+            new_state = "AWAITING_SLOT_PREFERENCE" # Let them try again
+            state_service.save_state(phone_number, new_state, context)
+          
+    elif state == "AWAITING_SLOT_CHOICE":
+        print(f"Handling AWAITING_SLOT_CHOICE for {phone_number}. Message: '{message_text}'")
+        chosen_slot_id = message_text.strip() # Assume message is the slot ID
+        
+        # TODO: Add validation for the format of chosen_slot_id if needed
+        
+        if scheduling_service is None: scheduling_service = SchedulingService()
+        
+        try:
+            reservation_result = scheduling_service.reserve_slot(chosen_slot_id)
+            
+            if reservation_result.get("success"): # Assuming reserve_slot returns a dict like {"success": True/False, ...}
+                # Slot successfully reserved (logically)
+                # TODO: Get the reserved slot details (like formatted time) for the confirmation message
+                reserved_time = reservation_result.get("formatted_time", "o horário selecionado") # Placeholder
+                
+                reply_message = (
+                    f"Ótimo! Seu horário para {reserved_time} foi pré-agendado com sucesso.\n"
+                    f"Nossa equipe irá verificar os documentos enviados e entrará em contato em breve para confirmar tudo. Obrigado!"
+                )
+                new_state = "APPOINTMENT_PENDING" # Move to a state indicating pending human review/confirmation
+                new_context["reserved_slot_id"] = chosen_slot_id # Store the reserved ID
+                state_service.save_state(phone_number, new_state, new_context)
+            else:
+                # Slot could not be reserved (e.g., already taken, invalid ID)
+                error_message = reservation_result.get("error", "Não foi possível reservar este horário. Pode ser que ele tenha sido ocupado ou o ID é inválido.")
+                reply_message = f"{error_message} Por favor, escolha outro horário da lista abaixo."
+                
+                # Re-fetch and display available slots
+                available_slots = scheduling_service.get_available_slots()
+                if not available_slots:
+                    reply_message = "Desculpe, não há mais horários disponíveis no momento. Por favor, entre em contato conosco."
+                    new_state = "HUMAN_TAKEOVER" # No slots left, escalate
+                    state_service.save_state(phone_number, new_state, context)
+                else:
+                    slot_options = []
+                    for slot in available_slots:
+                        try:
+                            from datetime import datetime
+                            start_dt = datetime.fromisoformat(slot['start_time'])
+                            formatted_time = start_dt.strftime("%d/%m/%Y às %H:%M")
+                            slot_options.append(f"- {formatted_time} (ID: {slot['slot_id']})")
+                        except (ValueError, KeyError):
+                             slot_options.append(f"- Horário inválido (ID: {slot.get('slot_id', 'N/A')})")
+                              
+                    reply_message += "\n\n" + "Aqui estão os horários atualizados:\n" + "\n".join(slot_options) + "\n\nPor favor, digite o ID do horário que deseja escolher."
+                    new_state = "AWAITING_SLOT_CHOICE" # Stay in this state, but show list again
+                    state_service.save_state(phone_number, new_state, context) # Update context if needed
+                    
+        except Exception as e:
+            print(f"Error reserving slot {chosen_slot_id}: {e}")
+            reply_message = "Ocorreu um erro ao tentar reservar seu horário. Por favor, tente novamente ou escolha outro horário da lista."
+            # Go back to showing the list
+            new_state = "AWAITING_SLOT_PREFERENCE" # Go back to the previous state to re-trigger list fetching
+            state_service.save_state(phone_number, new_state, context)
+    
+    else:
+        print(f"Unhandled state '{state}' for {phone_number}")
+        # Default reply or escalate?
+        reply_message = "Desculpe, não entendi. Um de nossos atendentes entrará em contato."
+        state_service.save_state(phone_number, "HUMAN_TAKEOVER", context)
+        # TODO: Add notification logic for human takeover
+    
+    # --- 5. Send Reply (if any) --- 
+    if reply_message:
+        await whatsapp_service.send_message(phone_number, reply_message)
 
-        if not sent:
-            raise RuntimeError("Falha no envio da mensagem")
 
-        return OutgoingMessage(success=True, detail="Mensagem enviada com sucesso", to=data["phone"])
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+@router.post("/webhook")
+async def receive_whatsapp_message(request: Request, background_tasks: BackgroundTasks):
+    """
+    Receives incoming messages from Meta WhatsApp API.
+    Immediately returns 200 OK to Meta and processes the message in the background.
+    """
+    payload = await request.json()
+    # Using background tasks is crucial to avoid timeouts from Meta
+    background_tasks.add_task(process_whatsapp_message, payload)
+    print("Received POST /webhook. Added to background tasks.")
+    return Response(status_code=status.HTTP_200_OK)

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from dotenv import load_dotenv
 
-from app.api import whatsapp, calendar, chatgpt, notifications, conversation
+from app.api import whatsapp, calendar, notifications, conversation
 
 load_dotenv()
 
@@ -18,7 +18,6 @@ templates = Jinja2Templates(directory="app/templates")
 # Inclui os routers
 app.include_router(whatsapp.router, prefix="/whatsapp")
 app.include_router(calendar.router, prefix="/calendar")
-app.include_router(chatgpt.router, prefix="/chatgpt")
 app.include_router(conversation_router, prefix="/conversation")
 app.include_router(notifications.router, prefix="/api/notifications", tags=["notifications"])
 app.include_router(conversation.router, prefix="/api/conversation", tags=["conversation"])

--- a/app/services/conversation_state_service.py
+++ b/app/services/conversation_state_service.py
@@ -1,0 +1,133 @@
+import sqlite3
+import json
+import os
+from typing import Optional, Dict, Any
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./health_gpt.db")
+# Extract the path from the URL (remove sqlite:///)
+DB_PATH = DATABASE_URL.split("///")[-1]
+
+class ConversationStateService:
+    """
+    Manages the state and context of conversations using an SQLite database.
+    """
+    def __init__(self, db_path: str = DB_PATH):
+        self.db_path = db_path
+        self._create_table()
+
+    def _get_db_connection(self):
+        """Establishes a connection to the SQLite database."""
+        conn = sqlite3.connect(self.db_path)
+        # Optional: Use Row factory for dictionary-like access, though not strictly needed here
+        # conn.row_factory = sqlite3.Row 
+        return conn
+
+    def _create_table(self):
+        """Creates the conversation_state table if it doesn't exist."""
+        conn = self._get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS conversation_state (
+                phone_number TEXT PRIMARY KEY,
+                state TEXT NOT NULL,
+                context TEXT,  -- Storing context as JSON string
+                last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+    def save_state(self, phone_number: str, state: str, context: Optional[Dict[str, Any]] = None):
+        """Saves or updates the state and context for a given phone number."""
+        conn = self._get_db_connection()
+        cursor = conn.cursor()
+        context_json = json.dumps(context) if context is not None else None
+        
+        cursor.execute("""
+            INSERT INTO conversation_state (phone_number, state, context, last_updated)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(phone_number) DO UPDATE SET
+                state = excluded.state,
+                context = excluded.context,
+                last_updated = CURRENT_TIMESTAMP;
+        """, (phone_number, state, context_json))
+        
+        conn.commit()
+        conn.close()
+        print(f"[StateService] Saved state for {phone_number}: State={state}, Context={context_json}")
+
+    def get_state(self, phone_number: str) -> Optional[Dict[str, Any]]:
+        """
+        Retrieves the state and context for a given phone number.
+        Returns None if the phone number is not found.
+        """
+        conn = self._get_db_connection()
+        cursor = conn.cursor()
+        
+        cursor.execute("""
+            SELECT state, context 
+            FROM conversation_state 
+            WHERE phone_number = ?
+        """, (phone_number,))
+        
+        row = cursor.fetchone()
+        conn.close()
+        
+        if row:
+            state, context_json = row
+            context = json.loads(context_json) if context_json else None
+            print(f"[StateService] Retrieved state for {phone_number}: State={state}, Context={context}")
+            return {"state": state, "context": context}
+        else:
+            print(f"[StateService] No state found for {phone_number}. Treating as NEW.")
+            return None # Indicate not found, can be treated as 'NEW' state by caller
+
+    def delete_state(self, phone_number: str):
+        """Deletes the state entry for a given phone number."""
+        conn = self._get_db_connection()
+        cursor = conn.cursor()
+        
+        cursor.execute("""
+            DELETE FROM conversation_state 
+            WHERE phone_number = ?
+        """, (phone_number,))
+        
+        conn.commit()
+        rows_deleted = cursor.rowcount
+        conn.close()
+        
+        if rows_deleted > 0:
+             print(f"[StateService] Deleted state for {phone_number}.")
+        else:
+            print(f"[StateService] No state found for {phone_number} to delete.")
+
+# Example Usage (for testing purposes)
+if __name__ == '__main__':
+    service = ConversationStateService()
+    
+    # Example save
+    test_phone = "+1234567890"
+    initial_context = {"attempt": 1, "last_message": "hello"}
+    service.save_state(test_phone, "AWAITING_TYPE", initial_context)
+    
+    # Example retrieve
+    state_info = service.get_state(test_phone)
+    print(f"Retrieved: {state_info}")
+    
+    # Example update
+    updated_context = {"attempt": 2, "last_message": "insurance", "insurance_name_guess": "BlueCross"}
+    service.save_state(test_phone, "AWAITING_INSURANCE_DOCS", updated_context)
+    state_info_updated = service.get_state(test_phone)
+    print(f"Retrieved updated: {state_info_updated}")
+
+    # Example retrieve non-existent
+    state_info_none = service.get_state("+0987654321")
+    print(f"Retrieved non-existent: {state_info_none}")
+
+    # Example delete
+    service.delete_state(test_phone)
+    state_info_deleted = service.get_state(test_phone)
+    print(f"Retrieved after delete: {state_info_deleted}") 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,5 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+asyncio_mode = "auto"
 addopts = "-v" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ pydantic==2.11.3
 pydantic_core==2.33.1
 pyparsing==3.2.3
 pytest==8.2.0
+pytest-asyncio==0.21.2
 python-dotenv==1.1.0
 requests==2.32.3
 requests-oauthlib==2.0.0
@@ -40,3 +41,4 @@ typing_extensions==4.13.2
 uritemplate==4.1.1
 urllib3==2.4.0
 uvicorn==0.34.2
+uvicorn[standard]==0.34.2

--- a/tests/api/test_whatsapp_api.py
+++ b/tests/api/test_whatsapp_api.py
@@ -1,0 +1,668 @@
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+from fastapi.testclient import TestClient
+from fastapi import status, BackgroundTasks
+
+# Import the main app and router
+# Assuming your main app instance is in 'app.main' and named 'app'
+# Adjust the import path if your structure is different
+from app.main import app 
+from app.api.whatsapp import router as whatsapp_router, VERIFY_TOKEN, process_whatsapp_message 
+from app.services.conversation_state_service import ConversationStateService
+from app.services.whatsapp_service import WhatsAppService
+from app.services.scheduling_service import SchedulingService
+from app.services.appointment_orchestrator import AppointmentOrchestrator
+
+# Include the WhatsApp router in the TestClient app instance
+app.include_router(whatsapp_router, prefix="/whatsapp_test") # Use a prefix to avoid conflicts if needed
+
+client = TestClient(app)
+
+# --- Fixtures and Mocks ---
+
+@pytest.fixture(autouse=True)
+def mock_env_vars(monkeypatch):
+    """ Mocks environment variables needed by the API. """
+    monkeypatch.setenv("VERIFY_TOKEN", "test_verify_token")
+    monkeypatch.setenv("GOOGLE_SCHEDULES_LINK", "http://fake.google.link")
+    # Add other env vars if needed
+
+@pytest.fixture
+def mock_state_service():
+    """ Mocks ConversationStateService. """
+    with patch('app.api.whatsapp.ConversationStateService', autospec=True) as mock:
+        instance = mock.return_value
+        instance.get_state = MagicMock(return_value=None) # Default: NEW state
+        instance.save_state = MagicMock()
+        yield instance
+
+@pytest.fixture
+def mock_whatsapp_service():
+    """ Mocks WhatsAppService. """
+    with patch('app.api.whatsapp.WhatsAppService', autospec=True) as mock:
+        instance = mock.return_value
+        instance.send_message = AsyncMock() # Needs to be AsyncMock if called with await
+        yield instance
+        
+@pytest.fixture
+def mock_scheduling_service():
+    """ Mocks SchedulingService. """
+    with patch('app.api.whatsapp.SchedulingService', autospec=True) as mock:
+        instance = mock.return_value
+        instance.get_available_slots = MagicMock(return_value=[]) # Default: No slots
+        instance.reserve_slot = MagicMock(return_value={"success": False, "error": "Mock reservation failed"}) # Default: Fail
+        yield instance
+
+@pytest.fixture
+def mock_orchestrator_service():
+    """ Mocks AppointmentOrchestrator. """
+    with patch('app.api.whatsapp.AppointmentOrchestrator', autospec=True) as mock:
+        instance = mock.return_value
+        instance.validate_insurance = MagicMock(return_value=False) # Default: Invalid insurance
+        instance.ACCEPTED_INSURANCES = ["GoodHealth", "SecurePlan"] # Example accepted
+        yield instance
+        
+@pytest.fixture
+def mock_background_tasks():
+    """ Mocks BackgroundTasks to run tasks immediately. """
+    # This allows testing the background task logic synchronously
+    class ImmediateBackgroundTasks(BackgroundTasks):
+        def add_task(self, func, *args, **kwargs) -> None:
+            # Run the task immediately instead of in the background
+            import asyncio
+            try:
+                # Check if the function is async
+                if asyncio.iscoroutinefunction(func):
+                    asyncio.run(func(*args, **kwargs))
+                else:
+                    func(*args, **kwargs)
+            except Exception as e:
+                 print(f"Error running background task {func.__name__}: {e}")
+                 raise # Re-raise the exception to fail the test
+
+    with patch('app.api.whatsapp.BackgroundTasks', new=ImmediateBackgroundTasks) as mock:
+         yield mock
+
+# --- Helper Function to Create Payload ---
+
+def create_whatsapp_payload(phone_number: str, message_text: str) -> dict:
+    """ Creates a simplified mock WhatsApp incoming message payload. """
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [{
+            "id": "WHATSAPP_BUSINESS_ACCOUNT_ID",
+            "changes": [{
+                "value": {
+                    "messaging_product": "whatsapp",
+                    "metadata": {
+                        "display_phone_number": "PHONE_NUMBER",
+                        "phone_number_id": "PHONE_NUMBER_ID"
+                    },
+                    "contacts": [{"profile": {"name": "User Name"}, "wa_id": phone_number}],
+                    "messages": [{
+                        "from": phone_number,
+                        "id": "MSG_ID",
+                        "timestamp": "TIMESTAMP",
+                        "text": {"body": message_text},
+                        "type": "text"
+                    }]
+                },
+                "field": "messages"
+            }]
+        }]
+    }
+
+# --- Test Cases Start Here ---
+
+# TODO: Add test cases for GET /webhook verification
+# TODO: Add test cases for POST /webhook covering different states
+
+@pytest.mark.asyncio
+async def test_webhook_verification_success(mock_env_vars):
+    """ Test successful webhook verification. """
+    # Patch the VERIFY_TOKEN specifically for this test's scope
+    with patch('app.api.whatsapp.VERIFY_TOKEN', 'test_verify_token'):
+        response = client.get(
+            "/whatsapp_test/webhook", 
+            params={
+                "hub.mode": "subscribe",
+                "hub.challenge": "challenge_code",
+                "hub.verify_token": "test_verify_token"
+            }
+        )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.text == "challenge_code"
+
+@pytest.mark.asyncio
+async def test_webhook_verification_failure_token(mock_env_vars):
+    """ Test webhook verification failure due to wrong token. """
+    response = client.get(
+        "/whatsapp_test/webhook", 
+        params={
+            "hub.mode": "subscribe",
+            "hub.challenge": "challenge_code",
+            "hub.verify_token": "wrong_token"
+        }
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+@pytest.mark.asyncio
+async def test_webhook_verification_failure_missing_params(mock_env_vars):
+    """ Test webhook verification failure due to missing parameters. """
+    response = client.get(
+        "/whatsapp_test/webhook", 
+        params={"hub.mode": "subscribe"}
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+@pytest.mark.asyncio
+async def test_post_webhook_new_contact(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_background_tasks # Include mocks needed by process_whatsapp_message
+):
+    """ Test receiving the first message from a new contact. """
+    phone_number = "1234567890"
+    payload = create_whatsapp_payload(phone_number, "Oi")
+    
+    # Ensure state service returns None for this user initially
+    mock_state_service.get_state.return_value = None 
+    
+    # Patch the link specifically for this test's scope
+    with patch('app.api.whatsapp.GOOGLE_SCHEDULES_LINK', 'http://fake.google.link'):
+        response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    # Assert endpoint returns OK immediately
+    assert response.status_code == status.HTTP_200_OK
+    
+    # Assert background task ran and services were called correctly
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    
+    # Check the welcome message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Bem-vindo(a)" in call_args[1]
+    assert "http://fake.google.link" in call_args[1]
+    assert "Como gostaria de prosseguir?" in call_args[1]
+    
+    # Check the state was saved correctly
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_INITIAL_CHOICE", 
+        {}
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_initial_choice_chat(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_background_tasks
+):
+    """ Test user choosing to chat in AWAITING_INITIAL_CHOICE state. """
+    phone_number = "1234567891"
+    message_text = "quero agendar por aqui"
+    payload = create_whatsapp_payload(phone_number, message_text)
+    
+    # Set initial state
+    mock_state_service.get_state.return_value = {"state": "AWAITING_INITIAL_CHOICE", "context": {}}
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    
+    # Check the correct follow-up message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Ok, vamos agendar por aqui" in call_args[1]
+    assert "particular ou por convênio?" in call_args[1]
+    
+    # Check the state transition
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_TYPE", 
+        {}
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_initial_choice_link(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_background_tasks
+):
+    """ Test user asking for the link in AWAITING_INITIAL_CHOICE state. """
+    phone_number = "1234567892"
+    message_text = "me manda o link"
+    payload = create_whatsapp_payload(phone_number, message_text)
+    
+    # Set initial state
+    mock_state_service.get_state.return_value = {"state": "AWAITING_INITIAL_CHOICE", "context": {}}
+    
+    # Patch the link specifically for this test's scope
+    with patch('app.api.whatsapp.GOOGLE_SCHEDULES_LINK', 'http://fake.google.link'):
+        response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    
+    # Check the correct link message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Ok! Use este link para agendar:" in call_args[1]
+    assert "http://fake.google.link" in call_args[1]
+    
+    # Check the state transition to REDIRECTED_TO_LINK
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "REDIRECTED_TO_LINK", 
+        {"link_sent": True}
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_type_private(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_background_tasks
+):
+    """ Test user choosing private consultation in AWAITING_TYPE state. """
+    phone_number = "1234567893"
+    message_text = "particular"
+    initial_context = {}
+    payload = create_whatsapp_payload(phone_number, message_text)
+    
+    # Set initial state
+    mock_state_service.get_state.return_value = {"state": "AWAITING_TYPE", "context": initial_context}
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    
+    # Check the private info message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Entendido. O atendimento particular funciona assim:" in call_args[1]
+    assert "Um de nossos atendentes entrará em contato" in call_args[1]
+    
+    # Check the state transition to HUMAN_TAKEOVER
+    expected_context = {"is_private": True} # Context should be updated
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "HUMAN_TAKEOVER", 
+        expected_context
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_type_insurance(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_background_tasks
+):
+    """ Test user choosing insurance consultation in AWAITING_TYPE state. """
+    phone_number = "1234567894"
+    message_text = "convenio"
+    initial_context = {}
+    payload = create_whatsapp_payload(phone_number, message_text)
+    
+    # Set initial state
+    mock_state_service.get_state.return_value = {"state": "AWAITING_TYPE", "context": initial_context}
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    
+    # Check the insurance name prompt was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Ok, qual o nome do seu convênio/plano de saúde?" in call_args[1]
+    
+    # Check the state transition
+    expected_context = {"is_private": False}
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_INSURANCE_NAME", 
+        expected_context
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_insurance_name_valid(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_orchestrator_service, # Need orchestrator for validation
+    mock_background_tasks
+):
+    """ Test user providing a valid insurance name. """
+    phone_number = "1234567895"
+    insurance_name = "GoodHealth"
+    initial_context = {"is_private": False}
+    payload = create_whatsapp_payload(phone_number, insurance_name)
+    
+    # Set initial state and mock validation result
+    mock_state_service.get_state.return_value = {"state": "AWAITING_INSURANCE_NAME", "context": initial_context}
+    mock_orchestrator_service.validate_insurance.return_value = True
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    mock_orchestrator_service.validate_insurance.assert_called_once_with(insurance_name)
+    
+    # Check the document request message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert f"Perfeito, atendemos {insurance_name}" in call_args[1]
+    assert "envie aqui no chat fotos legíveis" in call_args[1]
+    assert "documento de identidade" in call_args[1]
+    assert "carteirinha do convênio" in call_args[1]
+    
+    # Check the state transition
+    expected_context = {"is_private": False, "insurance_name": insurance_name}
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_DOCS_INSURANCE", 
+        expected_context
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_insurance_name_invalid(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_orchestrator_service, # Need orchestrator for validation
+    mock_background_tasks
+):
+    """ Test user providing an invalid insurance name. """
+    phone_number = "1234567896"
+    insurance_name = "BadHealth"
+    initial_context = {"is_private": False} 
+    payload = create_whatsapp_payload(phone_number, insurance_name)
+    
+    # Set initial state and mock validation result
+    mock_state_service.get_state.return_value = {"state": "AWAITING_INSURANCE_NAME", "context": initial_context}
+    mock_orchestrator_service.validate_insurance.return_value = False # Invalid
+    accepted_insurances_str = ", ".join(mock_orchestrator_service.ACCEPTED_INSURANCES)
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    mock_orchestrator_service.validate_insurance.assert_called_once_with(insurance_name)
+    
+    # Check the rejection message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert f"não estamos atendendo o convênio '{insurance_name}'" in call_args[1]
+    assert f"Aceitamos: {accepted_insurances_str}" in call_args[1]
+    assert "Gostaria de seguir como particular ou tentar informar outro convênio?" in call_args[1]
+    
+    # Check the state transition back to AWAITING_TYPE
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_TYPE", 
+        initial_context # Context might be reset or kept, check implementation (currently kept)
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_docs_insurance(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_background_tasks
+):
+    """ Test receiving a message (assumed docs) in AWAITING_DOCS_INSURANCE state. """
+    phone_number = "1234567897"
+    message_text = "aqui estão os documentos" # Actual content doesn't matter for this test
+    initial_context = {"is_private": False, "insurance_name": "GoodHealth"}
+    payload = create_whatsapp_payload(phone_number, message_text)
+    
+    # Set initial state
+    mock_state_service.get_state.return_value = {"state": "AWAITING_DOCS_INSURANCE", "context": initial_context}
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    
+    # Check the slot preference prompt was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Obrigado! Agora, sobre o agendamento" in call_args[1]
+    assert "preferência de dia ou horário" in call_args[1]
+    
+    # Check the state transition
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_SLOT_PREFERENCE", 
+        initial_context # Context should be preserved
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_slot_preference_slots_available(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_scheduling_service, # Need scheduling service
+    mock_background_tasks
+):
+    """ Test asking for slots in AWAITING_SLOT_PREFERENCE with available slots. """
+    phone_number = "1234567898"
+    message_text = "qualquer horário serve"
+    initial_context = {"is_private": False, "insurance_name": "GoodHealth"}
+    payload = create_whatsapp_payload(phone_number, message_text)
+    
+    # Define available slots
+    available_slots = [
+        {"slot_id": "slot1", "start_time": "2024-08-01T10:00:00", "end_time": "2024-08-01T10:30:00"},
+        {"slot_id": "slot2", "start_time": "2024-08-01T11:00:00", "end_time": "2024-08-01T11:30:00"}
+    ]
+    
+    # Set initial state and mock service results
+    mock_state_service.get_state.return_value = {"state": "AWAITING_SLOT_PREFERENCE", "context": initial_context}
+    mock_scheduling_service.get_available_slots.return_value = available_slots
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    mock_scheduling_service.get_available_slots.assert_called_once()
+    
+    # Check the slot list message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Aqui estão os próximos horários disponíveis:" in call_args[1]
+    assert "01/08/2024 às 10:00 (ID: slot1)" in call_args[1] # Check formatting
+    assert "01/08/2024 às 11:00 (ID: slot2)" in call_args[1]
+    assert "digite o ID do horário que deseja escolher" in call_args[1]
+    
+    # Check the state transition
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_SLOT_CHOICE", 
+        initial_context # Context should be preserved
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_slot_preference_no_slots(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_scheduling_service, # Need scheduling service
+    mock_background_tasks
+):
+    """ Test asking for slots in AWAITING_SLOT_PREFERENCE with no available slots. """
+    phone_number = "1234567899"
+    message_text = "tem horário hoje?"
+    initial_context = {"is_private": False, "insurance_name": "GoodHealth"}
+    payload = create_whatsapp_payload(phone_number, message_text)
+    
+    # Set initial state and mock service results
+    mock_state_service.get_state.return_value = {"state": "AWAITING_SLOT_PREFERENCE", "context": initial_context}
+    mock_scheduling_service.get_available_slots.return_value = [] # No slots
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    mock_scheduling_service.get_available_slots.assert_called_once()
+    
+    # Check the no slots message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Desculpe, no momento não há horários disponíveis" in call_args[1]
+    
+    # Check the state remains the same
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_SLOT_PREFERENCE", # Stays in the same state
+        initial_context 
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_slot_choice_success(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_scheduling_service, # Need scheduling service
+    mock_background_tasks
+):
+    """ Test successfully reserving a slot in AWAITING_SLOT_CHOICE state. """
+    phone_number = "1234567900"
+    chosen_slot_id = "slot1"
+    initial_context = {"is_private": False, "insurance_name": "GoodHealth"}
+    payload = create_whatsapp_payload(phone_number, chosen_slot_id)
+    
+    # Mock successful reservation
+    # Assuming reserve_slot returns formatted time on success
+    reservation_result = {"success": True, "formatted_time": "01/08/2024 às 10:00"}
+    
+    # Set initial state and mock service results
+    mock_state_service.get_state.return_value = {"state": "AWAITING_SLOT_CHOICE", "context": initial_context}
+    mock_scheduling_service.reserve_slot.return_value = reservation_result
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    mock_scheduling_service.reserve_slot.assert_called_once_with(chosen_slot_id)
+    
+    # Check the confirmation message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Ótimo! Seu horário para 01/08/2024 às 10:00 foi pré-agendado" in call_args[1]
+    assert "Nossa equipe irá verificar os documentos" in call_args[1]
+    
+    # Check the state transition to APPOINTMENT_PENDING
+    expected_context = initial_context.copy()
+    expected_context["reserved_slot_id"] = chosen_slot_id
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "APPOINTMENT_PENDING", 
+        expected_context 
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_slot_choice_fail_retry(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_scheduling_service, # Need scheduling service
+    mock_background_tasks
+):
+    """ Test failing to reserve a slot (e.g., taken) but other slots are available. """
+    phone_number = "1234567901"
+    chosen_slot_id = "slot_taken"
+    initial_context = {"is_private": False, "insurance_name": "GoodHealth"}
+    payload = create_whatsapp_payload(phone_number, chosen_slot_id)
+    
+    # Mock failed reservation
+    reservation_result = {"success": False, "error": "Slot just became unavailable."}
+    
+    # Mock other available slots for retry
+    available_slots_retry = [
+        {"slot_id": "slot_other", "start_time": "2024-08-02T14:00:00", "end_time": "2024-08-02T14:30:00"}
+    ]
+    
+    # Set initial state and mock service results
+    mock_state_service.get_state.return_value = {"state": "AWAITING_SLOT_CHOICE", "context": initial_context}
+    mock_scheduling_service.reserve_slot.return_value = reservation_result
+    mock_scheduling_service.get_available_slots.return_value = available_slots_retry # Called after failure
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    mock_scheduling_service.reserve_slot.assert_called_once_with(chosen_slot_id)
+    mock_scheduling_service.get_available_slots.assert_called_once() # Should be called to get new list
+    
+    # Check the error message AND the new slot list was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    assert "Slot just became unavailable." in call_args[1] # Error message
+    assert "Por favor, escolha outro horário" in call_args[1]
+    assert "Aqui estão os horários atualizados:" in call_args[1]
+    assert "02/08/2024 às 14:00 (ID: slot_other)" in call_args[1] # New slot
+    
+    # Check the state remains AWAITING_SLOT_CHOICE for retry
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "AWAITING_SLOT_CHOICE", # Stay in the same state
+        initial_context 
+    )
+
+@pytest.mark.asyncio
+async def test_post_webhook_awaiting_slot_choice_fail_no_slots(
+    mock_state_service,
+    mock_whatsapp_service,
+    mock_scheduling_service, # Need scheduling service
+    mock_background_tasks
+):
+    """ Test failing to reserve a slot and no other slots are available. """
+    phone_number = "1234567902"
+    chosen_slot_id = "slot_last_one_taken"
+    initial_context = {"is_private": False, "insurance_name": "GoodHealth"}
+    payload = create_whatsapp_payload(phone_number, chosen_slot_id)
+    
+    # Mock failed reservation
+    reservation_result = {"success": False, "error": "Slot invalid or taken."}
+    
+    # Mock no other available slots
+    available_slots_retry = []
+    
+    # Set initial state and mock service results
+    mock_state_service.get_state.return_value = {"state": "AWAITING_SLOT_CHOICE", "context": initial_context}
+    mock_scheduling_service.reserve_slot.return_value = reservation_result
+    mock_scheduling_service.get_available_slots.return_value = available_slots_retry # Called after failure
+    
+    response = client.post("/whatsapp_test/webhook", json=payload)
+    
+    assert response.status_code == status.HTTP_200_OK
+    mock_state_service.get_state.assert_called_once_with(phone_number)
+    mock_scheduling_service.reserve_slot.assert_called_once_with(chosen_slot_id)
+    mock_scheduling_service.get_available_slots.assert_called_once() # Should be called
+    
+    # Check the final error message was sent
+    mock_whatsapp_service.send_message.assert_called_once()
+    call_args = mock_whatsapp_service.send_message.call_args[0]
+    assert call_args[0] == phone_number
+    # The initial error message might be combined or just the final one sent
+    # Checking for the specific message when no slots are left after failure:
+    assert "Desculpe, não há mais horários disponíveis no momento." in call_args[1]
+    assert "Por favor, entre em contato conosco." in call_args[1]
+    
+    # Check the state transition to HUMAN_TAKEOVER
+    mock_state_service.save_state.assert_called_once_with(
+        phone_number, 
+        "HUMAN_TAKEOVER", # Escalate to human
+        initial_context 
+    )
+
+# TODO: Add tests for other states (AWAITING_INITIAL_CHOICE, AWAITING_TYPE, etc.)
+
+# TODO: Add more tests for POST scenarios... 


### PR DESCRIPTION
- Implementa a lógica de máquina de estados para o fluxo de conversa do WhatsApp em app/api/whatsapp.py, cobrindo:
    - Boas-vindas e escolha inicial (link vs chat).
    - Diferenciação entre atendimento particular e por convênio.
    - Validação de nome de convênio.
    - Solicitação de documentos para convênio.
    - Apresentação de horários disponíveis.
    - Reserva de horário (pré-agendamento).
    - Transição para HUMAN_TAKEOVER nos casos apropriados (particular, falha sem mais slots).
- Adiciona testes de API em tests/api/test_whatsapp_api.py para verificar os diferentes estados e transições.
- Corrige ImportError em app/main.py removendo referências à API de ChatGPT deletada.
- Corrige configuração do pytest-asyncio em pyproject.toml e atualiza versão para 0.21.2 para compatibilidade com pytest 8.2.
- Resolve falhas nos testes relacionadas ao mock de variáveis de ambiente e adiciona await em chamada assíncrona.