### PR TITLE
feat: Integrate Google Calendar event creation and fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,32 @@
-# Ignorar o ambiente virtual
+# Virtual Environment
 .venv/
 
-# Ignorar caches do Python
+# Python cache
 __pycache__/
-*.pyc
+*.py[cod]
 
-# Ignorar arquivos de configuração local
+# Configuration/Secrets
 *.env
+app/secrets/
+credentials.json # Keep specific credential files if stored outside app/secrets
+token.json       # Keep specific token files if stored outside app/secrets
+*.pem
+*.key
 
-# Ignorar arquivos de credenciais
-credentials.json
+# IDE/Editor files
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Build/dist artifacts
+build/
+dist/
+*.egg-info/
+
+# Test artifacts
+.pytest_cache/
+.coverage*
+htmlcov/


### PR DESCRIPTION
    This PR implements the Google Calendar integration for automatic appointment creation and includes related test fixes.

    **Changes:**

    *   **Calendar Service (`app/services/calendar_service.py`):**
        *   Created `CalendarService` with OAuth 2.0 authentication flow using `credentials.json` and `token.json` stored in `app/secrets/`.
        *   Implemented `create_calendar_event` method using the Google Calendar API v3 to insert events into the primary calendar.
    *   **WhatsApp API (`app/api/whatsapp.py`):**
        *   Integrates `CalendarService` into the `AWAITING_SLOT_CHOICE` handler.
        *   Calls `create_calendar_event` after successful internal slot reservation.
        *   Sends final confirmation message and sets state to `COMPLETED` on successful event creation.
        *   Calls `scheduling_service.cancel_appointment` to free the slot if event creation fails.
        *   Sets state to `HUMAN_TAKEOVER` on event creation failure.
    *   **Tests (`tests/api/test_whatsapp_api.py`):**
        *   Added `mock_calendar_service` fixture.
        *   Updated tests (especially `test_post_webhook_awaiting_slot_choice_success`) to use the calendar mock and assert correct final state and message.
        *   Fixed test failures related to previous logic changes and mock configurations.
    *   **Gitignore (`.gitignore`):**
        *   Added `app/secrets/` to prevent committing credentials (`credentials.json`, `token.json`).

    **Note:** Requires `credentials.json` for Google Calendar API access to be placed in `app/secrets/`. The first run might trigger the OAuth browser flow to generate `token.json`.