### PR TITLE
test: Add real API test for ChatGPTService and fix day lookup

### DIFF
--- a/app/tests/test_chatgpt.py
+++ b/app/tests/test_chatgpt.py
@@ -44,3 +44,56 @@ def test_generate_response_error_handling(mock_openai):
             service.generate_response("Test prompt")
         
         assert "Failed to generate response from OpenAI: Test error" in str(exc_info.value)
+
+# Fixture for the real ChatGPT service
+@pytest.fixture
+def real_chatgpt_service(use_real_api):
+    """Provides a real ChatGPTService instance, skipping if --use-real-api is not set."""
+    if not use_real_api:
+        pytest.skip("Skipping real API test for ChatGPT. Use --use-real-api flag to run.")
+    
+    print("\nInitializing real ChatGPTService...")
+    try:
+        service = ChatGPTService()
+        # Quick check if API key seems loaded (though constructor already checks)
+        if not service.api_key:
+             pytest.fail("OpenAI API key seems missing even after initialization.")
+        return service
+    except ValueError as e:
+        # Handle case where API key might still be missing despite user confirmation
+        pytest.fail(f"ValueError during ChatGPTService initialization: {e}. Ensure OPENAI_API_KEY is correctly set in .env")
+    except Exception as e:
+        pytest.fail(f"Unexpected error initializing real ChatGPTService: {e}")
+
+def test_real_generate_response(real_chatgpt_service):
+    """Tests generate_response against the actual OpenAI API."""
+    # The fixture real_chatgpt_service handles skipping and initialization
+    service = real_chatgpt_service 
+    
+    print("Running test with REAL OpenAI API...")
+    try:
+        # Define a simple prompt
+        prompt = "Translate the following English text to French: 'Hello, world!'"
+        system_message = "You are a helpful translation assistant."
+        
+        print(f"Sending prompt to OpenAI: '{prompt}' with system message: '{system_message}'")
+        
+        # Call the real API
+        response = service.generate_response(prompt, system_message)
+        
+        print(f"Received response from OpenAI: '{response}'")
+        
+        # Basic assertions: Check if response is a non-empty string
+        assert isinstance(response, str)
+        assert len(response) > 0
+        assert "Bonjour" in response # Let's add a basic content check
+        
+        print("Real API test successful.")
+
+    # No need for ValueError handling here, fixture handles initialization errors
+    except RuntimeError as e:
+        # Handle errors during API call (e.g., network issues, API errors)
+        pytest.fail(f"RuntimeError during OpenAI API call: {e}")
+    except Exception as e:
+        # Catch any other unexpected errors
+        pytest.fail(f"An unexpected error occurred during the real API test: {e}")


### PR DESCRIPTION
- Adds the capability to test ChatGPTService against the real OpenAI API using the --use-real-api flag and also includes the necessary fix for day lookups in the calendar service.